### PR TITLE
[04주차 박상우] 거스름돈

### DIFF
--- a/04주차/박상우/BOJ5585
+++ b/04주차/박상우/BOJ5585
@@ -1,0 +1,28 @@
+package BAEKJOON;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ_5585 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+        int paymoney = 1000 - N ;
+        int[] arr ={500, 100, 50, 10, 5, 1};
+        int i = 0;
+        int change = 0;
+        while (paymoney != 0){
+            if (paymoney / arr[i] > 0 ){
+                change = change + paymoney / arr[i]; //1 , 2
+                paymoney = paymoney % arr[i]; //120 , 20
+
+            }
+        else {
+            i++;
+            }
+        }
+        System.out.println(change);
+    }
+}


### PR DESCRIPTION
<!-- PR 제목: "[04주차 박상우] BOJ_5585_거스름돈" -->

## 🔎 문제 소개

-   **링크**:  https://boj.kr/5585
-   **제목**:  거스름돈
-   **분류**:
    -    그리디
    -    

## 🖊️ 풀이

-   **시간 복잡도**: $O(N)$
-   **입력의 크기**:  $ 0<= N < 1000 $
    
--> 
처음에 열심히 짰지만 시간초과가 나왔다. 
그래서 다른건 건드리지 않고 배열을 사용해 수정하니 다행히 정상적으로 출력이 되었다.
import java.io.BufferedReader;
import java.io.IOException;
import java.io.InputStreamReader;

//거스름돈 시간초과 코드
public class BOJ_5585_excesstime {
    public static void main(String[] args) throws IOException {
        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));

        int N = Integer.parseInt(br.readLine());
        int change = 0;
        int num = 0;
        int paymoney = 1000 - N;

        while (paymoney > 0) {
            if (paymoney / 500 > 0) {
                change = paymoney / 500;
                paymoney %= 500;
                num += change;
            } else if (paymoney / 100 > 0) {
                change = paymoney / 100;
                paymoney = paymoney % 100;
                num += change;
            } else if (paymoney / 50 > 0) {
                change = paymoney / 50;
                paymoney = paymoney % 50;
                num += change;
            } else if (paymoney / 10 > 0) {
                change = paymoney / 10;
                paymoney = paymoney % 10;
                num += change;
            } else if (paymoney / 5 > 0) {
                change = paymoney / 5;
                paymoney = paymoney % 5;
                num += change;
            } else{
                change = paymoney;
                num += change;
            }
        }
        System.out.println(num);
    }
}
-->